### PR TITLE
tasks/deps-debian.yml: change 'raw' to 'command'

### DIFF
--- a/tasks/deps-debian.yml
+++ b/tasks/deps-debian.yml
@@ -2,7 +2,7 @@
 
 # https://github.com/ansible/ansible/issues/25414#issuecomment-440549135
 - name: wait for any possibly running unattended upgrade to finish # noqa 301
-  raw: >-
+  command: >-
     systemd-run
       --property="After=apt-daily.service apt-daily-upgrade.service"
       --wait /bin/true


### PR DESCRIPTION
Fixes an issue whereby use of `raw` seemingly causes linebreaks to prematurely terminate the command on my system producing the following error (but it's recommended to avoid use of `raw` anyway unless necessary):

```
fatal: [myhostname]: FAILED! => {"changed": true, "msg": "non-zero return code", "rc": 127, "stderr": "Shared connection to myhostname closed.\r\n", "stderr_lines": ["Shared connection to myhostname closed."], "stdout": "\u001b[0;1;31mCommand line to execute required.\u001b[0m\r\n/bin/sh: 2: --property=After=apt-daily.service apt-daily-upgrade.service: not found\r\n/bin/sh: 3: --wait: not found\r\n", "stdout_lines": ["\u001b[0;1;31mCommand line to execute required.\u001b[0m", "/bin/sh: 2: --property=After=apt-daily.service apt-daily-upgrade.service: not found", "/bin/sh: 3: --wait: not found"]}
```