### PR TITLE
Add support for minimal EL8 Install

### DIFF
--- a/tasks/build-deps-redhat.yml
+++ b/tasks/build-deps-redhat.yml
@@ -2,6 +2,6 @@
 
 - name: install lmod build dependencies
   ansible.builtin.yum:
-    pkg: gcc
+    pkg: "gcc,make"
 
 ...

--- a/tasks/deps-redhat.yml
+++ b/tasks/deps-redhat.yml
@@ -3,5 +3,6 @@
 - name: install lmod dependencies
   ansible.builtin.yum:
     pkg: '{{ lmod_os_packages | join(",") }}'
+    enablerepo: '{{ lmod_os_repos | join(",") }}'
 
 ...

--- a/vars/redhat-6.yml
+++ b/vars/redhat-6.yml
@@ -1,5 +1,7 @@
 ---
 
+lmod_os_repos: []
+
 lmod_os_packages:
   - lua
   - lua-devel

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -1,5 +1,7 @@
 ---
 
+lmod_os_repos: []
+
 lmod_os_packages:
   - lua
   - lua-filesystem

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -1,7 +1,6 @@
 ---
 
 lmod_os_repos:
-  - epel
   - powertools 
 
 lmod_os_packages:

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -4,6 +4,7 @@ lmod_os_packages:
   - lua
   - lua-json
   - lua-lpeg
+  - lua-posix
   - lua-term
   - tcl
   - tcl-devel

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -1,10 +1,16 @@
 ---
 
+lmod_os_repos:
+  - epel
+  - powertools 
+
 lmod_os_packages:
   - lua
+  - lua-devel
   - lua-json
   - lua-lpeg
   - lua-term
+  - lua-posix
   - tcl
   - tcl-devel
 

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -4,7 +4,6 @@ lmod_os_packages:
   - lua
   - lua-json
   - lua-lpeg
-  - lua-posix
   - lua-term
   - tcl
   - tcl-devel


### PR DESCRIPTION
This pull request finishes support for EL8.  

It turns out there are a few packages that need to be included for lua and those are in the powertools Epel repo.  This was discovered when developing another ansible role internally that was leveraging this role on a barebones Rocky Linux 8 container.

Also, make isn't always installed by default and has been added to the build deps.

These changes have been tested using molecule and I am currently working on a pull request to add that to your repo.

