### PR TITLE
explicitly enable epel repo during installation (RedHat)

### DIFF
--- a/vars/redhat-6.yml
+++ b/vars/redhat-6.yml
@@ -1,6 +1,7 @@
 ---
 
-__lmod_os_repos: []
+__lmod_os_repos:
+  - epel
 
 __lmod_os_packages:
   - lua

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -1,6 +1,7 @@
 ---
 
-__lmod_os_repos: []
+__lmod_os_repos:
+  - epel
 
 __lmod_os_packages:
   - lua

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -1,6 +1,7 @@
 ---
 
 __lmod_os_repos:
+  - epel
   - powertools
 
 __lmod_os_packages:


### PR DESCRIPTION
It could be possible that the users configured the EPEL repo to be disabled by default on their hosts. 
Since we depend anyway on EPEL here, simply enable it explicitly one-time during installation, just in case it was disabled before.