### PR TITLE
add support for redhat 9

### DIFF
--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,0 +1,16 @@
+---
+
+__lmod_os_repos:
+  - crb
+
+__lmod_os_packages:
+  - lua
+  - lua-devel
+  - lua-posix
+  - tcl
+  - tcl-devel
+
+__lmod_lua_interpreter: /usr/bin/lua
+__lmod_luac_interpreter: /usr/bin/luac
+
+...


### PR DESCRIPTION
- need to use the crb repo now instead of powertools on RHEL9
- lua-json, lua-term, lua-lpeg do not exist anymore apparently