### PR TITLE
make temp dir for Lmod source configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@ lmod_prefix: '/opt/apps'
 
 lmod_module_root_path: '{{ lmod_prefix }}/modulefiles'
 
+lmod_source_temp_dir: '/tmp'
+
 # -----------------------------------------------------------------------------
 # spider cache
 # -----------------------------------------------------------------------------

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,7 +14,7 @@
   ansible.builtin.unarchive:
     copy: no
     src: '{{ __lmod_source_tarball_dest }}'
-    dest: '/tmp'
+    dest: '{{ lmod_source_temp_dir }}'
     creates: '{{ __lmod_source_path }}'
 
 - name: configure and install lmod from source

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,9 +13,9 @@ __lmod_install_link: '{{ __lmod_base_dir }}/lmod'
 __lmod_source_tarball_url: >-
   https://github.com/TACC/Lmod/archive/{{ lmod_version }}.tar.gz
 
-__lmod_source_tarball_dest: '/tmp/lmod-{{ lmod_version }}.tar.gz'
+__lmod_source_tarball_dest: '{{ lmod_source_temp_dir }}/lmod-{{ lmod_version }}.tar.gz'
 
-__lmod_source_path: '/tmp/Lmod-{{ lmod_version }}'
+__lmod_source_path: '{{ lmod_source_temp_dir }}/Lmod-{{ lmod_version }}'
 
 # -----------------------------------------------------------------------------
 # shell configuration


### PR DESCRIPTION
If `/tmp` is noexec, then this installation will fail.  This update supports setting the temp directory to another location, if needed.